### PR TITLE
feat: Implement theme toggle and light theme

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,16 +2,15 @@
 
 import * as React from 'react';
 import './globals.css';
-import { ReactNode, useEffect } from 'react';
+import { ReactNode } from 'react';
+import { ThemeProvider } from '~/contexts/theme-context';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
-  useEffect(() => {
-    document.documentElement.classList.add('dark');
-  }, []);
-
   return (
     <html lang="en">
-      <body className="bg-background text-white">{children}</body>
+      <ThemeProvider>
+        <body className="bg-background text-white">{children}</body>
+      </ThemeProvider>
     </html>
   );
 }

--- a/components/ui/shared-header.tsx
+++ b/components/ui/shared-header.tsx
@@ -3,9 +3,12 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Button } from "./button";
 import { ButtonColorful } from "./button-colorful";
+import { useTheme } from '~/contexts/theme-context';
+import { Moon, Sun } from 'lucide-react';
 
 export const SharedHeader = () => {
   const router = useRouter();
+  const { theme, toggleTheme } = useTheme();
 
   const handleGetInTouch = () => {
     if (window.location.pathname !== '/') {
@@ -50,6 +53,10 @@ export const SharedHeader = () => {
             onClick={handleGetInTouch}
           >
             Get in Touch
+          </Button>
+          <Button variant="outline" size="icon" onClick={toggleTheme}>
+            {theme === 'light' ? <Moon className="h-[1.2rem] w-[1.2rem]" /> : <Sun className="h-[1.2rem] w-[1.2rem]" />}
+            <span className="sr-only">Toggle theme</span>
           </Button>
         </div>
       </div>

--- a/contexts/theme-context.tsx
+++ b/contexts/theme-context.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+// Define the shape of the context data
+interface ThemeContextData {
+  theme: string;
+  toggleTheme: () => void;
+}
+
+// Create the context with a default value
+const ThemeContext = createContext<ThemeContextData | undefined>(undefined);
+
+// Define the props for the ThemeProvider
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+// Create the ThemeProvider component
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<string>('light'); // Default theme is light
+
+  // Function to toggle the theme
+  const toggleTheme = () => {
+    setTheme((prevTheme) => (prevTheme === 'light' ? 'dark' : 'light'));
+  };
+
+  // Effect to update documentElement class and local storage
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  // Effect to load theme from local storage on initial render
+  useEffect(() => {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme) {
+      setTheme(storedTheme);
+    }
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+// Custom hook to use the theme context
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
This commit introduces a theme toggle functionality and a light theme to the application.

Key changes:
- Created a `ThemeContext` and `ThemeProvider` to manage theme state (light/dark) and persistence in local storage.
- Updated `app/layout.tsx` to use the `ThemeProvider` and remove the default dark theme.
- Added a theme toggle button to `components/ui/shared-header.tsx` with Sun/Moon icons to indicate the current theme.
- The application now supports both light and dark themes, and you can switch between them.
- Theme preference is persisted across sessions using local storage.