### PR TITLE
feat: remove theme toggle and enforce dark theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,44 +4,6 @@
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
-
-    --radius: 0.5rem;
-
-    --color-1: 0 100% 63%;
-    --color-2: 270 100% 63%;
-    --color-3: 210 100% 63%;
-    --color-4: 195 100% 63%;
-    --color-5: 90 100% 63%;
-  }
-
   .dark {
     --background: 222.2 84% 4.9%;
     --foreground: 210 40% 98%;

--- a/components/ui/shared-header.tsx
+++ b/components/ui/shared-header.tsx
@@ -3,12 +3,9 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Button } from "./button";
 import { ButtonColorful } from "./button-colorful";
-import { useTheme } from '~/contexts/theme-context';
-import { Moon, Sun } from 'lucide-react';
 
 export const SharedHeader = () => {
   const router = useRouter();
-  const { theme, toggleTheme } = useTheme();
 
   const handleGetInTouch = () => {
     if (window.location.pathname !== '/') {
@@ -53,10 +50,6 @@ export const SharedHeader = () => {
             onClick={handleGetInTouch}
           >
             Get in Touch
-          </Button>
-          <Button variant="outline" size="icon" onClick={toggleTheme}>
-            {theme === 'light' ? <Moon className="h-[1.2rem] w-[1.2rem]" /> : <Sun className="h-[1.2rem] w-[1.2rem]" />}
-            <span className="sr-only">Toggle theme</span>
           </Button>
         </div>
       </div>

--- a/contexts/theme-context.tsx
+++ b/contexts/theme-context.tsx
@@ -3,7 +3,6 @@ import React, { createContext, useContext, useState, useEffect } from 'react';
 // Define the shape of the context data
 interface ThemeContextData {
   theme: string;
-  toggleTheme: () => void;
 }
 
 // Create the context with a default value
@@ -16,34 +15,18 @@ interface ThemeProviderProps {
 
 // Create the ThemeProvider component
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
-  const [theme, setTheme] = useState<string>('light'); // Default theme is light
+  const theme = 'dark'; // Always dark theme
 
-  // Function to toggle the theme
-  const toggleTheme = () => {
-    setTheme((prevTheme) => (prevTheme === 'light' ? 'dark' : 'light'));
-  };
-
-  // Effect to update documentElement class and local storage
+  // Effect to update documentElement class
   useEffect(() => {
     const root = window.document.documentElement;
-    if (theme === 'dark') {
-      root.classList.add('dark');
-    } else {
-      root.classList.remove('dark');
-    }
-    localStorage.setItem('theme', theme);
-  }, [theme]);
-
-  // Effect to load theme from local storage on initial render
-  useEffect(() => {
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme) {
-      setTheme(storedTheme);
-    }
+    root.classList.add('dark');
+    // Ensure light class is not present if it was somehow added externally
+    root.classList.remove('light'); 
   }, []);
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
I removed the theme toggle functionality and hardcoded the application to use the dark theme by default.

Key changes:
- I modified ThemeProvider to always apply the dark theme.
- I removed the theme toggle button from the shared header.
- I cleaned up globals.css by removing unused light theme variables.
- I verified that ThemeProvider is correctly wrapping the application layout.